### PR TITLE
Support parsing attr names and event ids from simpleperf files

### DIFF
--- a/src/features.rs
+++ b/src/features.rs
@@ -32,14 +32,16 @@ pub const HEADER_CLOCK_DATA: u32 = 29;
 pub const HEADER_HYBRID_TOPOLOGY: u32 = 30;
 pub const HEADER_HYBRID_CPU_PMU_CAPS: u32 = 31;
 
+/// simpleperf `FEAT_FILE`
+pub const HEADER_SIMPLEPERF_FILE: u32 = 128;
 /// simpleperf `FEAT_META_INFO`
-pub const HEADER_SIMPLEPERF_META_INFO: u32 = 128;
+pub const HEADER_SIMPLEPERF_META_INFO: u32 = 129;
 /// simpleperf `FEAT_DEBUG_UNWIND`
-pub const HEADER_SIMPLEPERF_DEBUG_UNWIND: u32 = 129;
+pub const HEADER_SIMPLEPERF_DEBUG_UNWIND: u32 = 130;
 /// simpleperf `FEAT_DEBUG_UNWIND_FILE`
-pub const HEADER_SIMPLEPERF_DEBUG_UNWIND_FILE: u32 = 130;
+pub const HEADER_SIMPLEPERF_DEBUG_UNWIND_FILE: u32 = 131;
 /// simpleperf `FEAT_FILE2`
-pub const HEADER_SIMPLEPERF_FILE2: u32 = 131;
+pub const HEADER_SIMPLEPERF_FILE2: u32 = 132;
 
 /// A piece of optional data stored in a perf.data file. Its data is contained in a
 /// "feature section" at the end of the file.
@@ -83,6 +85,7 @@ impl Feature {
     pub const CLOCK_DATA: Self = Self(HEADER_CLOCK_DATA);
     pub const HYBRID_TOPOLOGY: Self = Self(HEADER_HYBRID_TOPOLOGY);
     pub const HYBRID_CPU_PMU_CAPS: Self = Self(HEADER_HYBRID_CPU_PMU_CAPS);
+    pub const SIMPLEPERF_FILE: Self = Self(HEADER_SIMPLEPERF_FILE);
     pub const SIMPLEPERF_META_INFO: Self = Self(HEADER_SIMPLEPERF_META_INFO);
     pub const SIMPLEPERF_DEBUG_UNWIND: Self = Self(HEADER_SIMPLEPERF_DEBUG_UNWIND);
     pub const SIMPLEPERF_DEBUG_UNWIND_FILE: Self = Self(HEADER_SIMPLEPERF_DEBUG_UNWIND_FILE);
@@ -123,6 +126,7 @@ impl fmt::Debug for Feature {
             Self::CLOCK_DATA => "CLOCK_DATA".fmt(f),
             Self::HYBRID_TOPOLOGY => "HYBRID_TOPOLOGY".fmt(f),
             Self::HYBRID_CPU_PMU_CAPS => "HYBRID_CPU_PMU_CAPS".fmt(f),
+            Self::SIMPLEPERF_FILE => "SIMPLEPERF_FILE".fmt(f),
             Self::SIMPLEPERF_META_INFO => "SIMPLEPERF_META_INFO".fmt(f),
             Self::SIMPLEPERF_DEBUG_UNWIND => "SIMPLEPERF_DEBUG_UNWIND".fmt(f),
             Self::SIMPLEPERF_DEBUG_UNWIND_FILE => "SIMPLEPERF_DEBUG_UNWIND_FILE".fmt(f),


### PR DESCRIPTION
perf.data files created by simpleperf have neither a HEADER_EVENT_DESC nor event_types sections. This means we are currently unable to determine the name or event_ids associated with each attribute.

This patch adds support for parsing this data from simpleperf generated perf.data files. The attr names can be found by parsing the SIMPLEPERF_META_INFO feature section. This section is a null-separated list of keys and values, where the "event_type_info" field contains the data we need. The feature flag values for each simpleperf feature were off by one so this had to be corrected.

Each attr in the attr section contains an offset and size of its corresponding id section. We now parse these values for each attr when parsing a simpleperf file, allowing us to then parse the list of event_ids from the correct location.