### PR TITLE
feat: Add parser for CLOCK_DATA & CLOCKID headers

### DIFF
--- a/examples/perfdatainfo.rs
+++ b/examples/perfdatainfo.rs
@@ -33,6 +33,12 @@ fn main() {
     if let Ok(Some(perf_version)) = perf_file.perf_version() {
         println!("Perf version: {perf_version}");
     }
+    if let Ok(Some(frequency)) = perf_file.clock_frequency() {
+        println!("Clock frequency: {frequency} ns per tick");
+    }
+    if let Ok(Some(clock_data)) = perf_file.clock_data() {
+        println!("Clock data: {clock_data:?}");
+    }
 
     // Print the feature sections.
     let features = perf_file.features();


### PR DESCRIPTION
I would add tests, but you don't seem to have any?

I tested with perfdatainfo, and it seems to work correctly with the headers present and missing.

With CLOCK_MONOTONIC_RAW:

```
Clock frequency: 1 ns per tick
Clock data: ClockData { version: 1, clockid: 4, wall_clock_ns: 1755716670722542000, clockid_time_ns: 121146150322338 }
```

I haven't gotten perf to be able to record with any clock except monotonic/monotonic_raw (ID 1 and 4 respectively).

Interestingly I believe I found a bug in perf (but since the resolution is always 1, it doesn't matter:

```c
static void print_clockid(struct feat_fd *ff, FILE *fp)
{
	fprintf(fp, "# clockid frequency: %"PRIu64" MHz\n",
		ff->ph->env.clock.clockid_res_ns * 1000);
}
```

Based on how the data is written though, it is not in GHz like the code above would suggest, but in ns per tick (matching `clock_getres`).

This closes #16