### PR TITLE
Add auxtrace record

### DIFF
--- a/src/auxtrace.rs
+++ b/src/auxtrace.rs
@@ -1,0 +1,70 @@
+use byteorder::ByteOrder;
+use linux_perf_event_reader::RawData;
+
+/// Auxtrace data record.
+///
+/// This is usually used with Intel PT, which records the pure Intel PT data.
+pub struct Auxtrace<'a> {
+    /// Size of `aux_data`
+    pub size: u64,
+    /// Offset of this trace in the total trace
+    pub offset: u64,
+    /// Reference ID
+    pub reference: u64,
+    /// Index of this trace in the total trace
+    pub index: u32,
+    /// ID of thread that contributes to this trace
+    pub tid: u32,
+    /// ID of CPU that contributes to this trace
+    pub cpu: u32,
+    /// Pure data. The length of this data is guaranteed to be consistent
+    /// with the `size` field.
+    pub aux_data: RawData<'a>,
+}
+
+impl<'a> Auxtrace<'a> {
+    pub fn parse<T: ByteOrder>(mut data: RawData<'a>) -> Result<Self, std::io::Error> {
+        let size = data.read_u64::<T>()?;
+        let offset = data.read_u64::<T>()?;
+        let reference = data.read_u64::<T>()?;
+        let index = data.read_u32::<T>()?;
+        let tid = data.read_u32::<T>()?;
+        let cpu = data.read_u32::<T>()?;
+        let _reserved = data.read_u32::<T>()?;
+        let aux_data = data;
+        Ok(Self {
+            size,
+            offset,
+            reference,
+            index,
+            tid,
+            cpu,
+            aux_data,
+        })
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use byteorder::LittleEndian;
+    use linux_perf_event_reader::RawData;
+
+    use super::Auxtrace;
+
+    #[test]
+    fn parse() {
+        let data = RawData::Single(&[
+            0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0xf9, 0xcd, 0x2a, 0x49, 0x28, 0x04, 0x00, 0x00, 0x08, 0x00, 0x00, 0x00,
+            0x7a, 0x24, 0x00, 0x00, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        ]);
+        let auxtrace = Auxtrace::parse::<LittleEndian>(data).unwrap();
+        assert_eq!(auxtrace.size, 0x01);
+        assert_eq!(auxtrace.offset, 0x00);
+        assert_eq!(auxtrace.reference, 0x428492acdf9);
+        assert_eq!(auxtrace.index, 0x8);
+        assert_eq!(auxtrace.tid, 0x247a);
+        assert_eq!(auxtrace.cpu, 8);
+        assert_eq!(auxtrace.aux_data.len(), auxtrace.size as usize);
+    }
+}

--- a/src/auxtrace.rs
+++ b/src/auxtrace.rs
@@ -4,6 +4,7 @@ use linux_perf_event_reader::RawData;
 /// Auxtrace data record.
 ///
 /// This is usually used with Intel PT, which records the pure Intel PT data.
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Auxtrace<'a> {
     /// Size of `aux_data`
     pub size: u64,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,6 +41,7 @@
 //! # }
 //! ```
 
+mod auxtrace;
 mod build_id_event;
 mod constants;
 mod dso_info;
@@ -67,6 +68,7 @@ pub use prost;
 
 pub use linux_perf_event_reader::Endianness;
 
+pub use auxtrace::Auxtrace;
 pub use dso_info::DsoInfo;
 pub use dso_key::DsoKey;
 pub use error::{Error, ReadError};

--- a/src/record.rs
+++ b/src/record.rs
@@ -2,6 +2,7 @@ use byteorder::{BigEndian, ByteOrder, LittleEndian};
 use linux_perf_event_reader::RawEventRecord;
 use linux_perf_event_reader::{Endianness, RawData, RecordType};
 
+use crate::auxtrace::Auxtrace;
 use crate::constants::*;
 use crate::thread_map::ThreadMap;
 
@@ -26,6 +27,7 @@ pub enum PerfFileRecord<'a> {
 #[non_exhaustive]
 pub enum UserRecord<'a> {
     ThreadMap(ThreadMap<'a>),
+    Auxtrace(Auxtrace<'a>),
     Raw(RawUserRecord<'a>),
 }
 
@@ -148,7 +150,7 @@ impl<'a> RawUserRecord<'a> {
             // UserRecordType::PERF_FINISHED_ROUND => {},
             // UserRecordType::PERF_ID_INDEX => {},
             // UserRecordType::PERF_AUXTRACE_INFO => {},
-            // UserRecordType::PERF_AUXTRACE => {},
+            UserRecordType::PERF_AUXTRACE => UserRecord::Auxtrace(Auxtrace::parse::<T>(self.data)?),
             // UserRecordType::PERF_AUXTRACE_ERROR => {},
             UserRecordType::PERF_THREAD_MAP => {
                 UserRecord::ThreadMap(ThreadMap::parse::<T>(self.data)?)


### PR DESCRIPTION
When using perf to record Intel PT traces, there will be an `AUXTRACE` record in the perf.data, which will lead buggy behavior for current implementation:

Different from other records, the `AUXTRACE` records follows this format:

```plaintext
| perf_event_header | auxtrace header | auxtrace data |
```

The length of "auxtrace data" is determined by the first 8 byte in "auxtrace header". The original implementation in the `file_reader.rs` will treat "auxtrace data" as a new record header, leading to the buggy behavior.

To fix this, we should peek the first 8 byte in the auxtrace header, which forces me to add the `Seek` bound in the `PerfRecordIter`. Is this a breaking change? I think it's not. It's can only be constructed from `PerfRecordReader`, which already requires `R: Seek`. I only add this bound in the `impl` block. It's depend on your opinion whether we should add this bound also to the struct definition of `PerfRecordIter` and `PerfFileReader` :)