### PR TITLE
Support auxtrace records

### DIFF
--- a/src/auxtrace.rs
+++ b/src/auxtrace.rs
@@ -1,0 +1,71 @@
+use byteorder::ByteOrder;
+use linux_perf_event_reader::RawData;
+
+/// Auxtrace data record.
+///
+/// This is usually used with Intel PT, which records the pure Intel PT data.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Auxtrace<'a> {
+    /// Size of `aux_data`
+    pub size: u64,
+    /// Offset of this trace in the total trace
+    pub offset: u64,
+    /// Reference ID
+    pub reference: u64,
+    /// Index of this trace in the total trace
+    pub index: u32,
+    /// ID of thread that contributes to this trace
+    pub tid: u32,
+    /// ID of CPU that contributes to this trace
+    pub cpu: u32,
+    /// Pure data. The length of this data is guaranteed to be consistent
+    /// with the `size` field.
+    pub aux_data: RawData<'a>,
+}
+
+impl<'a> Auxtrace<'a> {
+    pub fn parse<T: ByteOrder>(mut data: RawData<'a>) -> Result<Self, std::io::Error> {
+        let size = data.read_u64::<T>()?;
+        let offset = data.read_u64::<T>()?;
+        let reference = data.read_u64::<T>()?;
+        let index = data.read_u32::<T>()?;
+        let tid = data.read_u32::<T>()?;
+        let cpu = data.read_u32::<T>()?;
+        let _reserved = data.read_u32::<T>()?;
+        let aux_data = data;
+        Ok(Self {
+            size,
+            offset,
+            reference,
+            index,
+            tid,
+            cpu,
+            aux_data,
+        })
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use byteorder::LittleEndian;
+    use linux_perf_event_reader::RawData;
+
+    use super::Auxtrace;
+
+    #[test]
+    fn parse() {
+        let data = RawData::Single(&[
+            0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0xf9, 0xcd, 0x2a, 0x49, 0x28, 0x04, 0x00, 0x00, 0x08, 0x00, 0x00, 0x00,
+            0x7a, 0x24, 0x00, 0x00, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        ]);
+        let auxtrace = Auxtrace::parse::<LittleEndian>(data).unwrap();
+        assert_eq!(auxtrace.size, 0x01);
+        assert_eq!(auxtrace.offset, 0x00);
+        assert_eq!(auxtrace.reference, 0x428492acdf9);
+        assert_eq!(auxtrace.index, 0x8);
+        assert_eq!(auxtrace.tid, 0x247a);
+        assert_eq!(auxtrace.cpu, 8);
+        assert_eq!(auxtrace.aux_data.len(), auxtrace.size as usize);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,6 +62,7 @@
 //! # }
 //! ```
 
+mod auxtrace;
 mod build_id_event;
 mod constants;
 #[cfg(feature = "zstd")]
@@ -90,6 +91,7 @@ pub use prost;
 
 pub use linux_perf_event_reader::Endianness;
 
+pub use auxtrace::Auxtrace;
 pub use dso_info::DsoInfo;
 pub use dso_key::DsoKey;
 pub use error::{Error, ReadError};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,7 +99,9 @@ pub use feature_sections::{AttributeDescription, CompressionInfo, NrCpus, Sample
 pub use features::{Feature, FeatureSet, FeatureSetIter};
 pub use file_reader::{PerfFileReader, PerfRecordIter};
 pub use perf_file::PerfFile;
-pub use record::{HeaderAttr, HeaderFeature, PerfFileRecord, RawUserRecord, UserRecord, UserRecordType};
+pub use record::{
+    HeaderAttr, HeaderFeature, PerfFileRecord, RawUserRecord, UserRecord, UserRecordType,
+};
 pub use simpleperf::{
     simpleperf_dso_type, SimpleperfDexFileInfo, SimpleperfElfFileInfo, SimpleperfFileRecord,
     SimpleperfKernelModuleInfo, SimpleperfSymbol, SimpleperfTypeSpecificInfo,

--- a/src/record.rs
+++ b/src/record.rs
@@ -2,6 +2,7 @@ use byteorder::{BigEndian, ByteOrder, LittleEndian, ReadBytesExt};
 use linux_perf_event_reader::RawEventRecord;
 use linux_perf_event_reader::{Endianness, PerfEventAttr, RawData, RecordType};
 
+use crate::auxtrace::Auxtrace;
 use crate::constants::*;
 use crate::features::Feature;
 use crate::thread_map::ThreadMap;
@@ -29,6 +30,7 @@ pub enum UserRecord<'a> {
     ThreadMap(ThreadMap<'a>),
     HeaderAttr(HeaderAttr),
     HeaderFeature(HeaderFeature),
+    Auxtrace(Auxtrace<'a>),
     Raw(RawUserRecord<'a>),
 }
 
@@ -161,7 +163,7 @@ impl<'a> RawUserRecord<'a> {
             // UserRecordType::PERF_FINISHED_ROUND => {},
             // UserRecordType::PERF_ID_INDEX => {},
             // UserRecordType::PERF_AUXTRACE_INFO => {},
-            // UserRecordType::PERF_AUXTRACE => {},
+            UserRecordType::PERF_AUXTRACE => UserRecord::Auxtrace(Auxtrace::parse::<T>(self.data)?),
             // UserRecordType::PERF_AUXTRACE_ERROR => {},
             // UserRecordType::PERF_CPU_MAP => {},
             // UserRecordType::PERF_STAT_CONFIG => {},


### PR DESCRIPTION
Supersedes #21. This PR includes @Evian-Zhang's changes to add the struct and the parsing. I've changed the record iteration code to do a second read of the auxtrace data after we've already read the auxtrace struct into the record buffer. This way we can keep just the Read bound.