### PR TITLE
Fix runaway memory usage when reading simpleperf files

### DIFF
--- a/src/file_reader.rs
+++ b/src/file_reader.rs
@@ -23,6 +23,14 @@ use super::section::PerfFileSection;
 use super::simpleperf;
 use super::sorter::Sorter;
 
+/// How many records between synthetic round boundaries when reading simpleperf
+/// files. Simpleperf heap-merges per-CPU buffers per wake-up but not globally,
+/// so a thread migrating across CPUs at a wake-up boundary can produce small
+/// clusters of out-of-order records. A delta of up to ~200 records has been
+/// observed in practice; 1024 gives comfortable headroom while keeping the
+/// sorter's in-flight buffer to O(2 * 1024) records.
+const SIMPLEPERF_SYNTHETIC_ROUND_SIZE: usize = 1024;
+
 /// A parser for the perf.data file format.
 ///
 /// # Example
@@ -181,6 +189,10 @@ impl<C: Read + Seek> PerfFileReader<C> {
         // reading records from it.
         cursor.seek(SeekFrom::Start(header.data_section.offset))?;
 
+        let is_simpleperf = feature_sections
+            .get(&Feature::SIMPLEPERF_META_INFO)
+            .is_some();
+
         let perf_file = PerfFile {
             endian,
             features: header.features,
@@ -197,6 +209,12 @@ impl<C: Read + Seek> PerfFileReader<C> {
             read_offset: 0,
             record_data_len: Some(header.data_section.size),
             sorter: Sorter::new(),
+            synthetic_round_size: if is_simpleperf {
+                Some(SIMPLEPERF_SYNTHETIC_ROUND_SIZE)
+            } else {
+                None
+            },
+            records_since_last_finished_round: 0,
             buffers_for_recycling: VecDeque::new(),
             current_event_body: Vec::new(),
             pending_first_record: None,
@@ -355,6 +373,10 @@ impl<R: Read> PerfFileReader<R> {
             }
         }
 
+        let is_simpleperf = feature_sections
+            .get(&Feature::SIMPLEPERF_META_INFO)
+            .is_some();
+
         let perf_file = PerfFile {
             endian,
             features: super::features::FeatureSet(features_array),
@@ -371,6 +393,12 @@ impl<R: Read> PerfFileReader<R> {
             read_offset: 0,
             record_data_len: None, // Unbounded for pipes
             sorter: Sorter::new(),
+            synthetic_round_size: if is_simpleperf {
+                Some(SIMPLEPERF_SYNTHETIC_ROUND_SIZE)
+            } else {
+                None
+            },
+            records_since_last_finished_round: 0,
             buffers_for_recycling: VecDeque::new(),
             current_event_body: Vec::new(),
             pending_first_record,
@@ -400,6 +428,16 @@ pub struct PerfRecordIter<R: Read> {
     parse_infos: Vec<RecordParseInfo>,
     event_id_to_attr_index: HashMap<u64, usize>,
     sorter: Sorter<RecordSortKey, PendingRecord>,
+    /// If `Some(n)`, inject a synthetic `finish_round()` call every `n`
+    /// records. Used for files whose writer (e.g. simpleperf) already emits
+    /// records in near-timestamp order but doesn't write
+    /// `PERF_RECORD_FINISHED_ROUND` markers. The synthetic rounds bound the
+    /// sorter's buffering — without them the sorter would hold the entire
+    /// file. The chosen `n` must comfortably exceed the worst-case
+    /// out-of-order window (in record count) of the writer.
+    synthetic_round_size: Option<usize>,
+    /// Counter used together with `synthetic_round_size`.
+    records_since_last_finished_round: usize,
     buffers_for_recycling: VecDeque<Vec<u8>>,
     /// For pipe mode: the first non-metadata record that was read during initialization
     pending_first_record: Option<(PerfEventHeader, Vec<u8>)>,
@@ -434,7 +472,7 @@ impl<R: Read> PerfRecordIter<R> {
         Ok(None)
     }
 
-    /// Reads events into self.sorter until a FINISHED_ROUND record is found
+    /// Reads events into self.sorter until a round boundary is found
     /// and self.sorter is non-empty, or until we've run out of records to read.
     fn read_next_round(&mut self) -> Result<(), Error> {
         if self.endian == Endianness::LittleEndian {
@@ -444,7 +482,8 @@ impl<R: Read> PerfRecordIter<R> {
         }
     }
 
-    /// Reads events into self.sorter until a FINISHED_ROUND record is found
+    /// Reads events into self.sorter until a round boundary is found (either
+    /// a FINISHED_ROUND record or a synthetic boundary for simpleperf files)
     /// and self.sorter is non-empty, or until we've run out of records to read.
     fn read_next_round_impl<T: ByteOrder>(&mut self) -> Result<(), Error> {
         // Handle pending first record from pipe mode initialization
@@ -483,6 +522,7 @@ impl<R: Read> PerfRecordIter<R> {
 
             if user_record_type == Some(UserRecordType::PERF_FINISHED_ROUND) {
                 self.sorter.finish_round();
+                self.records_since_last_finished_round = 0;
                 if self.sorter.has_more() {
                     // The sorter is non-empty. We're done.
                     return Ok(());
@@ -557,6 +597,18 @@ impl<R: Read> PerfRecordIter<R> {
                     self.process_record::<T>(header, buffer, Some(offset))?
                 }
                 _ => self.process_record::<T>(header, buffer, Some(offset))?,
+            }
+
+            // Auto-flush for simpleperf files
+            if let Some(round_size) = self.synthetic_round_size {
+                self.records_since_last_finished_round += 1;
+                if self.records_since_last_finished_round >= round_size {
+                    self.records_since_last_finished_round = 0;
+                    self.sorter.finish_round();
+                    if self.sorter.has_more() {
+                        return Ok(());
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
perf.data files from simpleperf do not contain any FINISHED_ROUND records. This means that our reader was buffering up the entire file before emitting any records.

This commit introduces automatic flushing, every 1024 records, when reading files from simpleperf. We detect simpleperf files based on presence of the `SIMPLEPERF_META_INFO` feature.

I tested this on the following file:
https://storage.googleapis.com/profiler-get-symbols-fixtures/large-simpleperf-with-some-backwards-records-perf.data.gz

This file contains 365 records with "backwards timestamps", ignoring mmap records. The largest distance between two unordered records is 164 records.

Simpleperf sorts records within each round before writing them to the file: https://cs.android.com/android/platform/superproject/+/android-latest-release:system/extras/simpleperf/RecordReadThread.cpp;l=526-543;drc=3a242294560febfbbeaefc2451da1a3ede59604b And it doesn't do any ordering when reading files, it just trusts that the records are more-or-less ordered.

But this still allows some bad orderings, more on that below. As a consequence, this commit does not disable our "sorter" entirely; instead, we pick an auto-flush record count that seems "big enough in practice". The chosen threshold is sufficient on the example file but doesn't guarantee fully correct ordering for all files.

Here's what likely happened in the two backwards-timestamp cases in the example: Thread T runs on CPU A for a bit, then gets scheduled out, and then runs on CPU B for a bit. However, round N only saw the records in the buffer for CPU B! The records for CPU A were only read in round N + 1. So the earlier records from CPU A made it into a later round than the records from CPU B. The file only contains two instances of this happening for the same thread. The other instances of bad timestamp orderings only affect records from unrelated threads running on different CPUs, and are mostly harmless.

The file does not contain any instances of bad ordering within the same CPU. And that's what we'd expect - the kernel writes records in the right order into the per-CPU buffer.

But different-CPU-same-thread reorderings can still be problematic for consumers of this data. For example, samply maintains per-thread "running on CPU X" state and emits per-thread stacks based on accumulated thread CPU time.

Separately from all this, simpleperf emits synthetic mmap events when it sees the first sample for a process, and those synthetic events just have fully incorrect timestamps.